### PR TITLE
A fix to a quite exploitable net message.

### DIFF
--- a/lua/xeninui/libs/essentials_sh.lua
+++ b/lua/xeninui/libs/essentials_sh.lua
@@ -22,7 +22,6 @@ if SERVER then
 
 	net.Receive( "XeninUI.FullClientInit", function( len, p )
 		if p.XeninUI_FullClientInit then
-			ErrorNoHalt( p:Nick() .. " -> already did init? Maybe sent net msg manually?\n" )
 			return
 		end
 

--- a/lua/xeninui/libs/essentials_sh.lua
+++ b/lua/xeninui/libs/essentials_sh.lua
@@ -22,7 +22,9 @@ if SERVER then
 
 	net.Receive( "XeninUI.FullClientInit", function( len, p )
 		if p.XeninUI_FullClientInit then
-			return
+			
+			print(p:Nick() .. " -> already did init? Maybe sent net msg manually?\n")
+		    return
 		end
 
 		hook.Run( "Xenin.OnClientFullInit", p )


### PR DESCRIPTION
I've removed the ErrorNoHalt and replaced it with a print statement. If you'd want some sort of stack trace you can PrintTable(debug.getinfo(2)).